### PR TITLE
Create alternate solution to Exercise 27

### DIFF
--- a/src/04-conditional-types-and-infer/27-infer-in-union-types.solution.3.ts
+++ b/src/04-conditional-types-and-infer/27-infer-in-union-types.solution.3.ts
@@ -1,0 +1,30 @@
+import { never } from "zod";
+import { Equal, Expect } from "../helpers/type-utils";
+
+const parser1 = {
+  parse: () => 1,
+};
+
+const parser2 = () => "123";
+
+const parser3 = {
+  extract: () => true,
+};
+
+const parser4 = {
+  test: () => "a",
+  test2: () => true,
+};
+
+type GetParserResult<T> = T extends
+  | Record<string, () => infer TResult>
+  | (() => infer TResult)
+  ? TResult
+  : never;
+
+type tests = [
+  Expect<Equal<GetParserResult<typeof parser1>, number>>,
+  Expect<Equal<GetParserResult<typeof parser2>, string>>,
+  Expect<Equal<GetParserResult<typeof parser3>, boolean>>,
+  Expect<Equal<GetParserResult<typeof parser4>, string | boolean>>
+];


### PR DESCRIPTION
This alternate solution (and tests) allow for a user to have multiple parser methods in an object, and grabs all possible return types.