### PR TITLE
Add .tool-versions file with versions of node and pnpm for asdf users

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+pnpm 7.28.0
+nodejs lts


### PR DESCRIPTION
hi 👋 

I just started this course and I thought it could be useful for [`asdf`](https://asdf-vm.com/) users to automatically have the correct nodejs and pnpm versions set up from the get-go.

if you don't want this file to be there, I totally understand (the clutter is real). feel free to close the PR and I'll take it as a sign to not create similar PRs in the future :]

and if you want to discuss how this works, ping me on twitter @lucianoratamero
thanks for the good work!