### PR TITLE
Stop the watcher when the exercise is fininshed

### DIFF
--- a/scripts/exercise.js
+++ b/scripts/exercise.js
@@ -34,8 +34,11 @@ if (!exerciseFile) {
   process.exit(1);
 }
 
+let watcher = null;
+const stop = (path) => watcher.unwatch(path);
+
 // One-liner for current directory
-chokidar.watch(exerciseFile).on("all", (event, path) => {
+watcher = chokidar.watch(exerciseFile).on("all", (event, path) => {
   const fileContents = fs.readFileSync(exerciseFile, "utf8");
 
   const containsVitest =
@@ -54,6 +57,7 @@ chokidar.watch(exerciseFile).on("all", (event, path) => {
       stdio: "inherit",
     });
     console.log("Typecheck complete. You finished the exercise!");
+    stop(path);
   } catch (e) {
     console.log("Failed. Try again!");
   }


### PR DESCRIPTION
This is super opinionated and I won't feel offended if you won't merge it, but this simple change saved me a lot of clicks.

I would love to the watcher to keep on watching if I work on my solution, but when it is successful, I would like it to stop. Saves me a ton of time by avoiding clicking `control + c` all the time. 